### PR TITLE
Remove typescript from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1876,11 +1876,6 @@
       "resolved": "https://registry.npmjs.org/@types/deep-freeze/-/deep-freeze-0.1.2.tgz",
       "integrity": "sha512-M6x29Vk4681dght4IMnPIcF1SNmeEm0c4uatlTFhp+++H1oDK1THEIzuCC2WeCBVhX+gU0NndsseDS3zaCtlcQ=="
     },
-    "@types/eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -1943,11 +1938,6 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
     },
     "@types/keygrip": {
       "version": "1.0.1",
@@ -2110,86 +2100,6 @@
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
-    },
-    "@typescript-eslint/eslint-plugin": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.0.tgz",
-      "integrity": "sha512-iCcXREU4RciLmLniwKLRPCOFVXrkF7z27XuHq5DrykpREv/mz6ztKAyLg2fdkM0hQC7659p5ZF5uStH7uzAJ/w==",
-      "requires": {
-        "@typescript-eslint/experimental-utils": "2.6.0",
-        "eslint-utils": "^1.4.2",
-        "functional-red-black-tree": "^1.0.1",
-        "regexpp": "^2.0.1",
-        "tsutils": "^3.17.1"
-      }
-    },
-    "@typescript-eslint/experimental-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.0.tgz",
-      "integrity": "sha512-34BAFpNOwHXeqT+AvdalLxOvcPYnCxA5JGmBAFL64RGMdP0u65rXjii7l/nwpgk5aLEE1LaqF+SsCU0/Cb64xA==",
-      "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.6.0",
-        "eslint-scope": "^5.0.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.0.tgz",
-          "integrity": "sha512-A3lSBVIdj2Gp0lFEL6in2eSPqJ33uAc3Ko+Y4brhjkxzjbzLnwBH22CwsW2sCo+iwogfIyvb56/AJri15H0u5Q==",
-          "requires": {
-            "debug": "^4.1.1",
-            "glob": "^7.1.4",
-            "is-glob": "^4.0.1",
-            "lodash.unescape": "4.0.1",
-            "semver": "^6.3.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
-    "@typescript-eslint/parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.6.0.tgz",
-      "integrity": "sha512-AvLejMmkcjRTJ2KD72v565W4slSrrzUIzkReu1JN34b8JnsEsxx7S9Xx/qXEuMQas0mkdUfETr0j3zOhq2DIqQ==",
-      "requires": {
-        "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.6.0",
-        "@typescript-eslint/typescript-estree": "2.6.0",
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.0.tgz",
-          "integrity": "sha512-A3lSBVIdj2Gp0lFEL6in2eSPqJ33uAc3Ko+Y4brhjkxzjbzLnwBH22CwsW2sCo+iwogfIyvb56/AJri15H0u5Q==",
-          "requires": {
-            "debug": "^4.1.1",
-            "glob": "^7.1.4",
-            "is-glob": "^4.0.1",
-            "lodash.unescape": "4.0.1",
-            "semver": "^6.3.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
     },
     "@typescript-eslint/typescript-estree": {
       "version": "1.6.0",
@@ -14918,16 +14828,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
-    },
-    "typescript-eslint": {
-      "version": "0.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-0.0.1-alpha.0.tgz",
-      "integrity": "sha512-1hNKM37dAWML/2ltRXupOq2uqcdRQyDFphl+341NTPXFLLLiDhErXx8VtaSLh3xP7SyHZdcCgpt9boYYVb3fQg=="
     },
     "ua-parser-js": {
       "version": "0.7.20",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "@reshuffle/fetch-runtime": "0.0.5",
     "@reshuffle/local-proxy": "^0.2.15",
     "@reshuffle/server-function": "0.0.9",
-    "@typescript-eslint/eslint-plugin": "^2.6.0",
-    "@typescript-eslint/parser": "^2.6.0",
     "bootstrap": "^4.3.1",
     "eslint": "^5.16.0",
     "eslint-config-react-app": "^5.0.2",
@@ -30,9 +28,7 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.0.1",
     "swagger-ui-express": "^4.1.2",
-    "swagger-ui-react": "^3.24.0",
-    "typescript": "^3.6.4",
-    "typescript-eslint": "0.0.1-alpha.0"
+    "swagger-ui-react": "^3.24.0"
   },
   "scripts": {
     "start": "cross-env EXTEND_ESLINT=true react-scripts start",


### PR DESCRIPTION
If typescript is used it should be used as a devDependency to avoid
upload due to current upload algorithim